### PR TITLE
Fix typos

### DIFF
--- a/R/ncdf-read.R
+++ b/R/ncdf-read.R
@@ -23,7 +23,7 @@ ncdf_stack <- function(path){
 #' @param varname single varname for which to extract bands
 #' @param dimension name of dimension from which to extract bands. Check available dimensions with `ncdf_extra_dims()`.
 #'
-#' @return a stack of rasterLayers containing values for `varname`` in each dimensional band.
+#' @return a stack of rasterLayers containing values for `varname` in each dimensional band.
 #' @export
 #'
 #' @examples

--- a/R/ncdf-read.R
+++ b/R/ncdf-read.R
@@ -18,7 +18,7 @@ ncdf_stack <- function(path){
 
 #' Stack bands from a third dimension into a single rasterStack
 #'
-#' Stack bands from a third dimension (eg time, depth) into a single rasterStack.
+#' Stack bands from a third dimension (e.g. time, depth) into a single rasterStack.
 #' @param path path to the ncdf file
 #' @param varname single varname for which to extract bands
 #' @param dimension name of dimension from which to extract bands. Check available dimensions with `ncdf_extra_dims()`.

--- a/man/ncdf_dimstack.Rd
+++ b/man/ncdf_dimstack.Rd
@@ -17,5 +17,5 @@ ncdf_dimstack(path, varname = NULL, dimension)
 a stack of rasterLayers containing values for \code{varname} in each dimensional band.
 }
 \description{
-Stack bands from a third dimension (eg time, depth) into a single rasterStack.
+Stack bands from a third dimension (e.g. time, depth) into a single rasterStack.
 }

--- a/man/ncdf_dimstack.Rd
+++ b/man/ncdf_dimstack.Rd
@@ -14,7 +14,7 @@ ncdf_dimstack(path, varname = NULL, dimension)
 \item{dimension}{name of dimension from which to extract bands. Check available dimensions with \code{ncdf_extra_dims()}.}
 }
 \value{
-a stack of rasterLayers containing values for `varname`` in each dimensional band.
+a stack of rasterLayers containing values for \code{varname} in each dimensional band.
 }
 \description{
 Stack bands from a third dimension (eg time, depth) into a single rasterStack.


### PR DESCRIPTION
Hi Anna,

please see the diff ;-)

There are a few more instances of `varname` not wrapped in ``` ` ```s. Shall I push such a formatting change into this PR before you merge, or you want to address the formatting yourself?

Cheers!